### PR TITLE
Allow string for command

### DIFF
--- a/podman-compose.py
+++ b/podman-compose.py
@@ -477,8 +477,10 @@ def container_to_args(cnt, dirname, podman_path, shared_vols):
     args.append(cnt.get('image'))  # command, ..etc.
     command = cnt.get('command')
     if command is not None:
-        # TODO: handle if command is string
-        args.extend(command)
+        if is_str(command):
+            args.extend([command])
+        else:
+            args.extend(command)
     return args
 
 


### PR DESCRIPTION
Fixes a regression compared to docker-compose. F.ex.

    command: --smallfiles

got translated to

    - - s m a l l f i l e s

on the command line. If option value is a string create a list with a
single entry before adding it to the command line.